### PR TITLE
fix: add maplibre copyright attribution control #3

### DIFF
--- a/src/registry/map.tsx
+++ b/src/registry/map.tsx
@@ -89,7 +89,9 @@ function Map({ children, styles, ...props }: MapProps) {
     const mapInstance = new MapLibreGL.Map({
       container: containerRef.current,
       style: mapStyle,
-      attributionControl: false,
+      attributionControl: {
+        compact: true,
+      },
       ...props,
     });
 


### PR DESCRIPTION
added copyright attribution control as requested by issue #3 

I also see in `map.json` there's a content that sets attribution control, please let me know if an update is required over there as well 