### PR TITLE
feat: add draggable marker example to markers section

### DIFF
--- a/src/app/docs/_components/examples/draggable-marker-example.tsx
+++ b/src/app/docs/_components/examples/draggable-marker-example.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { Map, MapMarker, MarkerContent, MarkerPopup } from "@/registry/map";
+import { MapPin } from "lucide-react";
+
+export function DraggableMarkerExample() {
+  const [draggableMarker, setDraggableMarker] = useState({
+    lng: -73.98,
+    lat: 40.75,
+  });
+
+  return (
+    <div className="h-[400px] w-full">
+      <Map center={[-73.98, 40.76]} zoom={12}>
+        <MapMarker
+          draggable
+          longitude={draggableMarker.lng}
+          latitude={draggableMarker.lat}
+          offset={[0, -14]}
+          onDragEnd={(lngLat) => {
+            setDraggableMarker({ lng: lngLat.lng, lat: lngLat.lat });
+          }}
+        >
+          <MarkerContent>
+            <div className="cursor-move">
+              <MapPin
+                className="fill-black stroke-white dark:fill-white"
+                size={28}
+              />
+            </div>
+          </MarkerContent>
+          <MarkerPopup offset={[0, -28]}>
+            <div className="space-y-1">
+              <p className="font-medium text-foreground">Coordinates</p>
+              <p className="text-xs text-muted-foreground">
+                {draggableMarker.lat.toFixed(4)},{" "}
+                {draggableMarker.lng.toFixed(4)}
+              </p>
+            </div>
+          </MarkerPopup>
+        </MapMarker>
+      </Map>
+    </div>
+  );
+}

--- a/src/app/docs/markers/page.tsx
+++ b/src/app/docs/markers/page.tsx
@@ -2,6 +2,7 @@ import { DocsLayout, DocsSection, DocsCode } from "../_components/docs";
 import { ComponentPreview } from "../_components/component-preview";
 import { MarkersExample } from "../_components/examples/markers-example";
 import { PopupExample } from "../_components/examples/popup-example";
+import { DraggableMarkerExample } from "../_components/examples/draggable-marker-example";
 import { getExampleSource } from "@/lib/get-example-source";
 import { Metadata } from "next";
 
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
 export default function MarkersPage() {
   const markersSource = getExampleSource("markers-example.tsx");
   const popupSource = getExampleSource("popup-example.tsx");
+  const draggableMarkerSource = getExampleSource("draggable-marker-example.tsx");
 
   return (
     <DocsLayout
@@ -47,6 +49,17 @@ export default function MarkersPage() {
 
       <ComponentPreview code={popupSource} className="h-[500px]">
         <PopupExample />
+      </ComponentPreview>
+
+      <DocsSection title="Draggable Marker">
+        <p>
+          Create draggable markers that users can move around the map. Click the
+          marker to see its current coordinates in a popup.
+        </p>
+      </DocsSection>
+
+      <ComponentPreview code={draggableMarkerSource}>
+        <DraggableMarkerExample />
       </ComponentPreview>
     </DocsLayout>
   );


### PR DESCRIPTION
### Summary
Adds a draggable marker example to the markers section.

### Motivation
Provides a reference implementation for draggable markers, demonstrating drag handling and marker state updates.

### Scope
- Additive change
- No breaking changes

### Demo

https://github.com/user-attachments/assets/e68529d3-87e7-45be-9467-3ab93fe3af00

