### PR TITLE
feat: add MapGeoJSON component to parse and display GeoJSON strings

### DIFF
--- a/src/app/docs/_components/docs-sidebar.tsx
+++ b/src/app/docs/_components/docs-sidebar.tsx
@@ -50,6 +50,7 @@ const navigation = [
       { title: "Popups", href: "/docs/popups", icon: MessageSquare },
       { title: "Routes", href: "/docs/routes", icon: Route },
       { title: "Clusters", href: "/docs/clusters", icon: Layers },
+      { title: "GeoJSON", href: "/docs/geojson", icon: Braces },
       { title: "Advanced Usage", href: "/docs/advanced-usage", icon: Wrench },
     ],
   },

--- a/src/app/docs/_components/examples/geojson-example.tsx
+++ b/src/app/docs/_components/examples/geojson-example.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { Map, MapGeoJSON, MapPopup, MapControls } from "@/registry/map";
+
+const exampleGeoJSON = `{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [13.4050, 52.5200]
+  },
+  "properties": {
+    "name": "Berlin"
+  }
+}`;
+
+const exampleFeatureCollection = `{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [13.4050, 52.5200]
+      },
+      "properties": {
+        "name": "Berlin"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [2.3522, 48.8566]
+      },
+      "properties": {
+        "name": "Paris"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [13.4050, 52.5200],
+          [2.3522, 48.8566]
+        ]
+      },
+      "properties": {
+        "name": "Route"
+      }
+    }
+  ]
+}`;
+
+export function GeoJSONExample() {
+  const [selectedFeature, setSelectedFeature] = useState<{
+    coordinates: [number, number];
+    properties: Record<string, unknown>;
+  } | null>(null);
+
+  return (
+    <div className="space-y-4">
+      <div className="h-[400px] w-full">
+        <Map center={[8.0, 50.5]} zoom={5} fadeDuration={0}>
+          <MapGeoJSON
+            data={exampleFeatureCollection}
+            pointStyle={{
+              color: "#ef4444",
+              radius: 8,
+            }}
+            lineStyle={{
+              color: "#3b82f6",
+              width: 4,
+            }}
+            onClick={(feature, coordinates) => {
+              setSelectedFeature({
+                coordinates,
+                properties: feature.properties || {},
+              });
+            }}
+          />
+
+          {selectedFeature && (
+            <MapPopup
+              key={`${selectedFeature.coordinates[0]}-${selectedFeature.coordinates[1]}`}
+              longitude={selectedFeature.coordinates[0]}
+              latitude={selectedFeature.coordinates[1]}
+              onClose={() => setSelectedFeature(null)}
+              closeOnClick={false}
+              focusAfterOpen={false}
+              closeButton
+            >
+              <div className="space-y-1 p-1">
+                {Object.entries(selectedFeature.properties).map(
+                  ([key, value]) => (
+                    <p key={key} className="text-sm">
+                      <strong>{key}:</strong> {String(value)}
+                    </p>
+                  )
+                )}
+              </div>
+            </MapPopup>
+          )}
+
+          <MapControls />
+        </Map>
+      </div>
+
+      <div className="rounded-md border bg-muted p-4">
+        <h3 className="mb-2 text-sm font-semibold">Example GeoJSON String:</h3>
+        <pre className="overflow-x-auto text-xs">
+          <code>{exampleGeoJSON}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/docs/advanced-usage/page.tsx
+++ b/src/app/docs/advanced-usage/page.tsx
@@ -70,7 +70,7 @@ export default function AdvancedPage() {
     <DocsLayout
       title="Advanced Usage"
       description="Access the underlying MapLibre GL instance for advanced customization."
-      prev={{ title: "Clusters", href: "/docs/clusters" }}
+      prev={{ title: "GeoJSON", href: "/docs/geojson" }}
     >
       <DocsSection>
         <p>

--- a/src/app/docs/api-reference/page.tsx
+++ b/src/app/docs/api-reference/page.tsx
@@ -26,6 +26,7 @@ const anatomyCode = `<Map>
   <MapControls />
   <MapRoute coordinates={...} />
   <MapClusterLayer data={...} />
+  <MapGeoJSON data={...} />
 </Map>`;
 
 const useMapCode = `const { map, isLoaded } = useMap();`;
@@ -570,6 +571,73 @@ export default function ApiReferencePage() {
               type: "(clusterId: number, coordinates: [number, number], pointCount: number) => void",
               description:
                 "Callback when a cluster is clicked. If not provided, zooms into the cluster.",
+            },
+          ]}
+        />
+      </DocsSection>
+
+      {/* MapGeoJSON */}
+      <DocsSection title="MapGeoJSON">
+        <p>
+          Parses and displays GeoJSON data (as a string or parsed object) on the
+          map. Automatically detects geometry types and applies appropriate
+          styling. Supports all GeoJSON geometry types: Point, LineString,
+          Polygon, and their Multi- variants. Must be used inside{" "}
+          <DocsCode>Map</DocsCode>.
+        </p>
+        <DocsPropTable
+          props={[
+            {
+              name: "data",
+              type: "string | GeoJSON.GeoJSON",
+              description:
+                "GeoJSON data as a string or parsed object. Supports Feature, FeatureCollection, and all geometry types.",
+            },
+            {
+              name: "id",
+              type: "string",
+              description:
+                "Optional unique identifier for the GeoJSON layer. Useful when using multiple GeoJSON layers.",
+            },
+            {
+              name: "pointStyle",
+              type: "{ color?: string; radius?: number; opacity?: number }",
+              default: '{ color: "#3b82f6", radius: 6, opacity: 1 }',
+              description: "Styling options for point geometries.",
+            },
+            {
+              name: "lineStyle",
+              type: "{ color?: string; width?: number; opacity?: number; dashArray?: [number, number] }",
+              default: '{ color: "#4285F4", width: 3, opacity: 0.8 }',
+              description: "Styling options for line geometries.",
+            },
+            {
+              name: "polygonStyle",
+              type: "{ fillColor?: string; fillOpacity?: number; outlineColor?: string; outlineWidth?: number; outlineOpacity?: number }",
+              default: '{ fillColor: "#4285F4", fillOpacity: 0.3, outlineColor: "#4285F4", outlineWidth: 2, outlineOpacity: 1 }',
+              description: "Styling options for polygon geometries.",
+            },
+            {
+              name: "onClick",
+              type: "(feature: GeoJSON.Feature, coordinates: [number, number]) => void",
+              description: "Callback when a feature is clicked.",
+            },
+            {
+              name: "onMouseEnter",
+              type: "(feature: GeoJSON.Feature) => void",
+              description: "Callback when mouse enters a feature.",
+            },
+            {
+              name: "onMouseLeave",
+              type: "() => void",
+              description: "Callback when mouse leaves a feature.",
+            },
+            {
+              name: "interactive",
+              type: "boolean",
+              default: "true",
+              description:
+                "Whether the GeoJSON is interactive - shows pointer cursor on hover.",
             },
           ]}
         />

--- a/src/app/docs/clusters/page.tsx
+++ b/src/app/docs/clusters/page.tsx
@@ -16,7 +16,7 @@ export default function ClustersPage() {
       title="Clusters"
       description="Visualize large datasets with automatic point clustering."
       prev={{ title: "Routes", href: "/docs/routes" }}
-      next={{ title: "Advanced Usage", href: "/docs/advanced-usage" }}
+      next={{ title: "GeoJSON", href: "/docs/geojson" }}
     >
       <DocsSection>
         <p>

--- a/src/app/docs/geojson/page.tsx
+++ b/src/app/docs/geojson/page.tsx
@@ -1,0 +1,69 @@
+import {
+  DocsLayout,
+  DocsSection,
+  DocsCode,
+} from "../_components/docs";
+import { ComponentPreview } from "../_components/component-preview";
+import { GeoJSONExample } from "../_components/examples/geojson-example";
+import { getExampleSource } from "@/lib/get-example-source";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "GeoJSON",
+};
+
+export default function GeoJSONPage() {
+  const geojsonSource = getExampleSource("geojson-example.tsx");
+
+  return (
+    <DocsLayout
+      title="GeoJSON"
+      description="Parse and display GeoJSON strings or objects on your map."
+      prev={{ title: "Clusters", href: "/docs/clusters" }}
+      next={{ title: "Advanced Usage", href: "/docs/advanced-usage" }}
+    >
+      <DocsSection>
+        <p>
+          Use <DocsCode>MapGeoJSON</DocsCode> to automatically parse and display
+          GeoJSON data on your map. The component accepts GeoJSON as a string or
+          parsed object, and automatically handles different geometry types
+          (Point, LineString, Polygon, and their Multi- variants).
+        </p>
+      </DocsSection>
+
+      <DocsSection title="Basic Example">
+        <p>
+          Display GeoJSON features with automatic styling. The component
+          automatically detects geometry types and applies appropriate styles.
+          Click on features to see their properties in a popup.
+        </p>
+      </DocsSection>
+
+      <ComponentPreview code={geojsonSource} className="h-[500px]">
+        <GeoJSONExample />
+      </ComponentPreview>
+
+      <DocsSection title="Features">
+        <ul className="list-disc space-y-2 pl-6">
+          <li>
+            Automatically parses GeoJSON strings or accepts parsed objects
+          </li>
+          <li>
+            Supports all GeoJSON geometry types: Point, LineString, Polygon,
+            and their Multi- variants
+          </li>
+          <li>
+            Customizable styling for points, lines, and polygons
+          </li>
+          <li>
+            Interactive features with click and hover callbacks
+          </li>
+          <li>
+            Works with single Features or FeatureCollections
+          </li>
+        </ul>
+      </DocsSection>
+    </DocsLayout>
+  );
+}
+


### PR DESCRIPTION
This commit implements the MapGeoJSON component as requested in issue #30. The component automatically parses GeoJSON strings and displays them on the map with support for all geometry types.

New Features:
- MapGeoJSON component in src/registry/map.tsx (+408 lines)
  * Accepts GeoJSON as string (auto-parsed) or parsed object
  * Automatically detects geometry types (Point, LineString, Polygon, Multi- variants)
  * Creates appropriate map layers for each geometry type
  * Customizable styling via pointStyle, lineStyle, and polygonStyle props
  * Interactive features with onClick, onMouseEnter, onMouseLeave callbacks
  * Supports Feature, FeatureCollection, and all geometry types

Documentation:
- Added example component: src/app/docs/_components/examples/geojson-example.tsx
  * Demonstrates parsing GeoJSON strings
  * Shows FeatureCollection with multiple geometry types
  * Includes interactive popups with feature properties

- Added documentation page: src/app/docs/geojson/page.tsx
  * Component overview and usage guide
  * Live example with code preview
  * Feature list

- Updated API reference: src/app/docs/api-reference/page.tsx
  * Added MapGeoJSON section with complete prop documentation
  * Updated component anatomy example

- Updated sidebar navigation: src/app/docs/_components/docs-sidebar.tsx
  * Added GeoJSON link between Clusters and Advanced Usage

Navigation Updates:
- Updated clusters/page.tsx: Changed next link from Advanced Usage to GeoJSON
- Updated advanced-usage/page.tsx: Changed prev link from Clusters to GeoJSON (Maintains proper navigation flow: Clusters → GeoJSON → Advanced Usage)

Technical Details:
- Uses MapLibre GL's GeoJSON source support
- Creates separate layers for points (circle), lines (line), polygons (fill + outline)
- Handles dynamic updates when GeoJSON data changes
- Proper cleanup of layers and sources on unmount
- Full TypeScript support with proper types

Fixes #30