### PR TITLE
Add map projection support

### DIFF
--- a/src/app/docs/_components/docs-sidebar.tsx
+++ b/src/app/docs/_components/docs-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Wrench,
   Settings,
   Layers,
+  Globe,
 } from "lucide-react";
 
 import {
@@ -46,6 +47,7 @@ const navigation = [
     items: [
       { title: "Basic Map", href: "/docs/basic-map", icon: Map },
       { title: "Map Controls", href: "/docs/controls", icon: Settings },
+      { title: "Map Projection", href: "/docs/map-projection", icon: Globe },
       { title: "Markers", href: "/docs/markers", icon: MapPin },
       { title: "Popups", href: "/docs/popups", icon: MessageSquare },
       { title: "Routes", href: "/docs/routes", icon: Route },

--- a/src/app/docs/_components/examples/map-projection-example.tsx
+++ b/src/app/docs/_components/examples/map-projection-example.tsx
@@ -1,0 +1,11 @@
+import { Map, MapControls } from "@/registry/map";
+
+export function MapProjectionExample() {
+  return (
+    <div className="h-[400px] w-full">
+      <Map center={[0, 20]} zoom={1.5}>
+        <MapControls showZoom={false} showProjection />
+      </Map>
+    </div>
+  );
+}

--- a/src/app/docs/_components/examples/projection-custom-ui-example.tsx
+++ b/src/app/docs/_components/examples/projection-custom-ui-example.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+import { Map } from "@/registry/map";
+import { Globe, Map as MapIcon } from "lucide-react";
+
+export function ProjectionCustomUIExample() {
+  const [projection, setProjection] = useState<"globe" | "mercator">("mercator");
+
+  return (
+    <div className="h-[400px] w-full">
+      <Map projection={projection} center={[0, 20]} zoom={1.5}>
+        <div className="absolute top-4 left-4 flex gap-2">
+          <button
+            onClick={() => setProjection("mercator")}
+            className={`flex items-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors ${
+              projection === "mercator"
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-background/90 backdrop-blur border-border hover:bg-accent"
+            }`}
+          >
+            <MapIcon className="size-4" />
+            Flat
+          </button>
+          <button
+            onClick={() => setProjection("globe")}
+            className={`flex items-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors ${
+              projection === "globe"
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-background/90 backdrop-blur border-border hover:bg-accent"
+            }`}
+          >
+            <Globe className="size-4" />
+            Globe
+          </button>
+        </div>
+      </Map>
+    </div>
+  );
+}

--- a/src/app/docs/_components/examples/projection-external-example.tsx
+++ b/src/app/docs/_components/examples/projection-external-example.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { Map } from "@/registry/map";
+
+export function ProjectionExternalExample() {
+  const [projection, setProjection] = useState<"globe" | "mercator">(
+    "mercator"
+  );
+
+  return (
+    <div className="flex flex-col">
+      <div className="p-2 flex items-center justify-between">
+        <span className="text-sm text-muted-foreground">
+          Current: <strong className="text-foreground">{projection}</strong>
+        </span>
+        <button
+          onClick={() =>
+            setProjection((p) => (p === "globe" ? "mercator" : "globe"))
+          }
+          className="px-3 py-1.5 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          Toggle Projection
+        </button>
+      </div>
+      <div className="h-88 w-full">
+        <Map projection={projection} center={[0, 20]} zoom={1.5} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/docs/api-reference/page.tsx
+++ b/src/app/docs/api-reference/page.tsx
@@ -93,6 +93,12 @@ export default function ApiReferencePage() {
               description:
                 "Custom map styles for light and dark themes. Overrides the default Carto base map tiles.",
             },
+            {
+              name: "projection",
+              type: '"globe" | "mercator"',
+              description:
+                "Map projection type. Use 'mercator' for a flat map or 'globe' for a 3D spherical view. Optional. When provided, the map will enforce this projection. When omitted, MapControls can manage projection independently.",
+            },
           ]}
         />
       </DocsSection>
@@ -154,6 +160,12 @@ export default function ApiReferencePage() {
               type: "boolean",
               default: "false",
               description: "Show fullscreen toggle button.",
+            },
+            {
+              name: "showProjection",
+              type: "boolean",
+              default: "false",
+              description: "Show projection toggle button. Toggles between globe and mercator projections.",
             },
             {
               name: "className",

--- a/src/app/docs/controls/page.tsx
+++ b/src/app/docs/controls/page.tsx
@@ -16,7 +16,7 @@ export default function ControlsPage() {
       title="Map Controls"
       description="Add interactive controls to your map for zoom, compass, location, and fullscreen."
       prev={{ title: "Basic Map", href: "/docs/basic-map" }}
-      next={{ title: "Markers", href: "/docs/markers" }}
+      next={{ title: "Map Projection", href: "/docs/map-projection" }}
     >
       <DocsSection>
         <p>

--- a/src/app/docs/map-projection/page.tsx
+++ b/src/app/docs/map-projection/page.tsx
@@ -1,0 +1,72 @@
+import { DocsLayout, DocsSection, DocsCode } from "../_components/docs";
+import { ComponentPreview } from "../_components/component-preview";
+import { MapProjectionExample } from "../_components/examples/map-projection-example";
+import { ProjectionCustomUIExample } from "../_components/examples/projection-custom-ui-example";
+import { ProjectionExternalExample } from "../_components/examples/projection-external-example";
+import { getExampleSource } from "@/lib/get-example-source";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Map Projection",
+};
+
+export default function MapProjectionPage() {
+  const projectionSource = getExampleSource("map-projection-example.tsx");
+  const customUISource = getExampleSource("projection-custom-ui-example.tsx");
+  const externalSource = getExampleSource("projection-external-example.tsx");
+
+  return (
+    <DocsLayout
+      title="Map Projection"
+      description="Switch between globe and mercator projections for different map views."
+      prev={{ title: "Map Controls", href: "/docs/controls" }}
+      next={{ title: "Markers", href: "/docs/markers" }}
+    >
+      <DocsSection>
+        <p>
+          The <DocsCode>Map</DocsCode> component supports two projection types:{" "}
+          <DocsCode>mercator</DocsCode> for the traditional flat map (default)
+          and <DocsCode>globe</DocsCode> for a 3D spherical view.
+        </p>
+        <p>
+          The <DocsCode>projection</DocsCode> prop is fully reactive. Change it
+          at any time and the map will transition to the new projection.
+        </p>
+      </DocsSection>
+
+      <DocsSection title="Using MapControls">
+        <p>
+          The easiest way to add projection switching is with the built-in{" "}
+          <DocsCode>MapControls</DocsCode> component. Set{" "}
+          <DocsCode>showProjection</DocsCode> to display a toggle button.
+        </p>
+      </DocsSection>
+
+      <ComponentPreview code={projectionSource}>
+        <MapProjectionExample />
+      </ComponentPreview>
+
+      <DocsSection title="Custom UI">
+        <p>
+          Since <DocsCode>projection</DocsCode> is just a prop, you can build
+          any UI to control it.
+        </p>
+      </DocsSection>
+
+      <ComponentPreview code={customUISource}>
+        <ProjectionCustomUIExample />
+      </ComponentPreview>
+
+      <DocsSection title="External Control">
+        <p>
+          The projection can be controlled from anywhere in your component tree.
+          The button doesn&apos;t need to be inside the map.
+        </p>
+      </DocsSection>
+
+      <ComponentPreview code={externalSource}>
+        <ProjectionExternalExample />
+      </ComponentPreview>
+    </DocsLayout>
+  );
+}

--- a/src/app/docs/markers/page.tsx
+++ b/src/app/docs/markers/page.tsx
@@ -27,7 +27,7 @@ export default function MarkersPage() {
     <DocsLayout
       title="Markers"
       description="Add interactive markers to your map with popups and tooltips."
-      prev={{ title: "Map Controls", href: "/docs/controls" }}
+      prev={{ title: "Map Projection", href: "/docs/map-projection" }}
       next={{ title: "Popups", href: "/docs/popups" }}
     >
       <DocsSection>


### PR DESCRIPTION
  Summary

  Added the ability to switch between flat map (mercator) and 3D globe projections.

  You can either use the new showProjection toggle in MapControls, or control it yourself with the projection prop on the Map component.

  Changes

  - Map component now accepts an optional projection prop
  - MapControls has a new showProjection button
  - Added documentation page with examples
  - Updated API reference
