### PR TITLE
fix: satisfy noUncheckedIndexedAccess in MapClusterLayer click handlers

### DIFF
--- a/src/registry/map.tsx
+++ b/src/registry/map.tsx
@@ -1382,7 +1382,7 @@ function MapClusterLayer<
       });
       if (!features.length) return;
 
-      const feature = features[0];
+      const feature = features[0]!;
       const clusterId = feature.properties?.cluster_id as number;
       const pointCount = feature.properties?.point_count as number;
       const coordinates = (feature.geometry as GeoJSON.Point).coordinates as [
@@ -1411,7 +1411,7 @@ function MapClusterLayer<
     ) => {
       if (!onPointClick || !e.features?.length) return;
 
-      const feature = e.features[0];
+      const feature = e.features[0]!;
       const coordinates = (
         feature.geometry as GeoJSON.Point
       ).coordinates.slice() as [number, number];


### PR DESCRIPTION
### Problem

When the `map` component is installed into a project that has `"noUncheckedIndexedAccess": true` in its `tsconfig`, `MapClusterLayer` fails to compile with:

```
src/registry/map.tsx(1385,..): error TS18048: 'feature' is possibly 'undefined'.
src/registry/map.tsx(1414,..): error TS18048: 'feature' is possibly 'undefined'.
```

Both occurrences are guarded by preceding length checks (`if (!features.length) return;` and `if (!onPointClick || !e.features?.length) return;`), so the array access is provably safe — TypeScript just can't narrow it under that flag.

### Change

Two non-null assertions on the `features[0]` / `e.features[0]` accesses. Zero runtime impact.

### Why upstream

MapCN's own `tsconfig.json` doesn't enable `noUncheckedIndexedAccess`, so the flag isn't exercised by your CI. But the component is shipped via the registry into arbitrary downstream projects, and stricter-TS consumers hit the failure immediately. Absorbing the two `!`s upstream keeps the component drop-in for that audience.